### PR TITLE
updateing Java version in install.sh

### DIFF
--- a/DevOps-Pipeline-PHP/laravel-app/install.sh
+++ b/DevOps-Pipeline-PHP/laravel-app/install.sh
@@ -2,7 +2,7 @@
 echo "--------------------Installing Java--------------------"
 sudo apt-get update -y
 sudo apt upgrade -y 
-sudo apt-get install openjdk-8-jdk -y
+sudo apt-get install openjdk-11-jre
 #Install Jenkins 
 echo "--------------------Installing Jenkins--------------------"
 sudo apt -y install wget


### PR DESCRIPTION
Updating Java version due to Newer versions of Jenkins require at least Java version 11,  Modified in install.sh  to sudo apt-get install openjdk-11-jre